### PR TITLE
Add ROI metric in win-rate comparison

### DIFF
--- a/arena_ev.py
+++ b/arena_ev.py
@@ -194,10 +194,14 @@ for p in wr_list:
         eb = sum(box_table[k] * v for k, v in d.items())
         ej_total = ej + eb * (box_price_dollar / jem_price_dollar)
         nj = ej_total - entry_cost
+        exp_trials = 1
+    cost = entry_cost * exp_trials
+    ev_pct = (nj / cost * 100) if cost else 0
     scenario.append({
         "勝率": p,
         "純期待利益(ジェム)": nj,
-        "純期待利益(ドル)": nj * jem_price_dollar
+        "純期待利益(ドル)": nj * jem_price_dollar,
+        "期待値(%)": ev_pct
     })
 sc_df = pd.DataFrame(scenario)
 


### PR DESCRIPTION
## Summary
- compute expected value (ROI) percentage for each win-rate scenario
- display the new `期待値(%)` column in the scenario results table

## Testing
- `python -m py_compile arena_ev.py`
- `python -c "import streamlit, sys; print('streamlit', streamlit.__version__)"` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68598f770bec8333a6b58b7c5cb50579