### PR TITLE
Fix EV% formula

### DIFF
--- a/arena_ev.py
+++ b/arena_ev.py
@@ -192,13 +192,14 @@ for p in wr_list:
     else:
         ej = sum(reward_table[k] * v for k, v in d.items())
         eb = sum(box_table[k] * v for k, v in d.items())
-        ej_total = ej + eb * (box_price_dollar / jem_price_dollar)
-        nj = ej_total - entry_cost
+        rev_jem_total = ej + eb * (box_price_dollar / jem_price_dollar)
+        nj = rev_jem_total - entry_cost
         exp_trials = 1
     cost = entry_cost * exp_trials
     cost_dollar = cost * jem_price_dollar
-    nj_dollar = nj * jem_price_dollar
-    ev_pct = (nj_dollar / cost_dollar * 100) if cost_dollar else 0
+    rev_dollar_total = rev_jem_total * jem_price_dollar
+    nj_dollar = rev_dollar_total - cost_dollar
+    ev_pct = (rev_dollar_total / cost_dollar * 100) if cost_dollar else 0
     scenario.append({
         "勝率": p,
         "純期待利益(ジェム)": nj,


### PR DESCRIPTION
## Summary
- fix EV percentage so 100% corresponds to zero net profit

## Testing
- `python -m py_compile arena_ev.py`


------
https://chatgpt.com/codex/tasks/task_e_685992790840833385e0751cecc2d767